### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.7f1 to 2022.2.9f1-urp

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.2",
+      "version": "1.8.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.7f1
-m_EditorVersionWithRevision: 2022.2.7f1 (8331acaee5d3)
+m_EditorVersion: 2022.2.9f1
+m_EditorVersionWithRevision: 2022.2.9f1 (1cc571a6ec95)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.9f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.9f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.9f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)