### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.12f1 to 2022.2.13f1

### DIFF
--- a/Assets/WebGLTemplates/Release/pretty-console.js.meta
+++ b/Assets/WebGLTemplates/Release/pretty-console.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ea70a7885f4b5d035af2158717e39a14
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.12f1
-m_EditorVersionWithRevision: 2022.2.12f1 (022dac4955a3)
+m_EditorVersion: 2022.2.13f1
+m_EditorVersionWithRevision: 2022.2.13f1 (5f5de2657605)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.13f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.13f1-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.13f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)