### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.12f1 to 2022.2.13f1-urp

### DIFF
--- a/Assets/WebGLTemplates/Release/pretty-console.js.meta
+++ b/Assets/WebGLTemplates/Release/pretty-console.js.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3d84f494eae79b4db9f7ca4c7ebbb448
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.0.1",
+    "com.unity.collab-proxy": "2.0.3",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.18",
     "com.unity.ide.visualstudio": "2.0.17",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.12f1
-m_EditorVersionWithRevision: 2022.2.12f1 (022dac4955a3)
+m_EditorVersion: 2022.2.13f1
+m_EditorVersionWithRevision: 2022.2.13f1 (5f5de2657605)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.13f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.13f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.13f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)