### PR TITLE
[Automated workflow] upgrade-unity from 2021.3.21f1 to 2021.3.22f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.0.1",
+    "com.unity.collab-proxy": "2.0.3",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.18",
     "com.unity.ide.visualstudio": "2.0.17",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.0.1",
+      "version": "2.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.21f1
-m_EditorVersionWithRevision: 2021.3.21f1 (1b156197d683)
+m_EditorVersion: 2021.3.22f1
+m_EditorVersionWithRevision: 2021.3.22f1 (b6c551784ba3)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2021.3.22f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2021.3.22f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2021.3.22f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)