### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.13f1 to 2022.2.14f1-urp

### DIFF
--- a/Assets/WebGLTemplates/Develop/index.html
+++ b/Assets/WebGLTemplates/Develop/index.html
@@ -150,7 +150,7 @@
     if(isMobile) {
       // Define a maximum pixel ratio for mobile to avoid rendering at too high resolutions
       const maxPixelRatioMobile = 2.0;
-      config.devicePixelRatio = Math.min(window.devicePixelRatio, maxDevicePixelRatio);
+      config.devicePixelRatio = Math.min(window.devicePixelRatio, maxPixelRatioMobile);
     }
 
     var canvas = document.querySelector("#unity-canvas");

--- a/Assets/WebGLTemplates/Release/index.html
+++ b/Assets/WebGLTemplates/Release/index.html
@@ -149,7 +149,7 @@
     if(isMobile) {
       // Define a maximum pixel ratio for mobile to avoid rendering at too high resolutions
       const maxPixelRatioMobile = 2.0;
-      config.devicePixelRatio = Math.min(window.devicePixelRatio, maxDevicePixelRatio);
+      config.devicePixelRatio = Math.min(window.devicePixelRatio, maxPixelRatioMobile);
     }
 
     var canvas = document.querySelector("#unity-canvas");

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,7 +5,7 @@
     "com.unity.ide.rider": "3.0.18",
     "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.render-pipelines.universal": "14.0.6",
+    "com.unity.render-pipelines.universal": "14.0.7",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.3",
+      "version": "1.8.4",
       "depth": 1,
       "source": "registry",
       "dependencies": {
@@ -73,7 +73,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "14.0.6",
+      "version": "14.0.7",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -84,14 +84,14 @@
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "14.0.6",
+      "version": "14.0.7",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
         "com.unity.burst": "1.8.2",
-        "com.unity.render-pipelines.core": "14.0.6",
-        "com.unity.shadergraph": "14.0.6"
+        "com.unity.render-pipelines.core": "14.0.7",
+        "com.unity.shadergraph": "14.0.7"
       }
     },
     "com.unity.searcher": {
@@ -109,11 +109,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "14.0.6",
+      "version": "14.0.7",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "14.0.6",
+        "com.unity.render-pipelines.core": "14.0.7",
         "com.unity.searcher": "4.9.2"
       }
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.13f1
-m_EditorVersionWithRevision: 2022.2.13f1 (5f5de2657605)
+m_EditorVersion: 2022.2.14f1
+m_EditorVersionWithRevision: 2022.2.14f1 (b2c9b1ac6cc0)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.14f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.14f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.14f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)