### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.14f1 to 2022.2.15f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": "1.1.1",
+    "com.unity.ai.navigation": "1.1.3",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.18",
-    "com.unity.ide.visualstudio": "2.0.17",
+    "com.unity.ide.rider": "3.0.20",
+    "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ai.navigation": {
-      "version": "1.1.1",
+      "version": "1.1.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -34,7 +34,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.18",
+      "version": "3.0.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -43,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.17",
+      "version": "2.0.18",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.14f1
-m_EditorVersionWithRevision: 2022.2.14f1 (b2c9b1ac6cc0)
+m_EditorVersion: 2022.2.15f1
+m_EditorVersionWithRevision: 2022.2.15f1 (30d813e1a2a9)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.15f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.15f1-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.15f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)