### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.15f1 to 2022.2.17f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.0.3",
+    "com.unity.collab-proxy": "2.0.4",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.20",
+    "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "14.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.0.3",
+      "version": "2.0.4",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -41,7 +41,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.15f1
-m_EditorVersionWithRevision: 2022.2.15f1 (30d813e1a2a9)
+m_EditorVersion: 2022.2.17f1
+m_EditorVersionWithRevision: 2022.2.17f1 (54cb9bda89c4)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.17f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.17f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.17f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)