### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.17f1 to 2022.2.18f1-urp

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -89,7 +89,7 @@
       "source": "builtin",
       "dependencies": {
         "com.unity.mathematics": "1.2.1",
-        "com.unity.burst": "1.8.2",
+        "com.unity.burst": "1.8.4",
         "com.unity.render-pipelines.core": "14.0.7",
         "com.unity.shadergraph": "14.0.7"
       }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.17f1
-m_EditorVersionWithRevision: 2022.2.17f1 (54cb9bda89c4)
+m_EditorVersion: 2022.2.18f1
+m_EditorVersionWithRevision: 2022.2.18f1 (5ebc6493a86f)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.18f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.18f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.18f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)