### PR TITLE
[Automated workflow] upgrade-unity from 2020.3.47f1 to 2020.3.48f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.20",
+    "com.unity.ide.rider": "3.0.21",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -25,7 +25,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.20",
+      "version": "3.0.21",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.47f1
-m_EditorVersionWithRevision: 2020.3.47f1 (5ef4f5b5e2d4)
+m_EditorVersion: 2020.3.48f1
+m_EditorVersionWithRevision: 2020.3.48f1 (b805b124c6b7)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2020.3.48f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2020.3.48f1-webgl2
* https://deml.io/experiments/unity-webgl/2020.3.48f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)