### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.1f1 to 2022.3.2f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.collab-proxy": "2.0.5",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.22",
+    "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "14.0.8",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -41,7 +41,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.22",
+      "version": "3.0.24",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.1f1
-m_EditorVersionWithRevision: 2022.3.1f1 (f18e0c1b5784)
+m_EditorVersion: 2022.3.2f1
+m_EditorVersionWithRevision: 2022.3.2f1 (d74737c6db50)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.2f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.2f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.2f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)