### PR TITLE
[Automated workflow] upgrade-unity from 2023.1.0f1 to 2023.1.1f1-urp

### DIFF
--- a/Assets/URP/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Assets/URP/UniversalRenderPipelineAsset_Renderer.asset
@@ -54,6 +54,10 @@ MonoBehaviour:
       type: 3}
     objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
       type: 3}
+    screenSpaceLensFlare: {fileID: 4800000, guid: 701880fecb344ea4c9cd0db3407ab287,
+      type: 3}
+    dataDrivenLensFlare: {fileID: 4800000, guid: 6cda457ac28612740adb23da5d39ea92,
+      type: 3}
   m_AssetVersion: 2
   m_OpaqueLayerMask:
     serializedVersion: 2

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,11 +2,11 @@
   "dependencies": {
     "com.unity.collab-proxy": "2.0.5",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.22",
+    "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "15.0.6",
-    "com.unity.test-framework": "1.3.5",
+    "com.unity.test-framework": "1.3.7",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -41,7 +41,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.22",
+      "version": "3.0.24",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -119,7 +119,7 @@
       }
     },
     "com.unity.test-framework": {
-      "version": "1.3.5",
+      "version": "1.3.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2023.1.0f1
-m_EditorVersionWithRevision: 2023.1.0f1 (a008fa768e6c)
+m_EditorVersion: 2023.1.1f1
+m_EditorVersionWithRevision: 2023.1.1f1 (46620eadcc07)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2023.1.1f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2023.1.1f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2023.1.1f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)