### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.2f1 to 2022.3.3f1-urp

### DIFF
--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.4",
+      "version": "1.8.7",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.2f1
-m_EditorVersionWithRevision: 2022.3.2f1 (d74737c6db50)
+m_EditorVersion: 2022.3.3f1
+m_EditorVersionWithRevision: 2022.3.3f1 (7cdc2969a641)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.3f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.3f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.3f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)