### PR TITLE
[Automated workflow] upgrade-unity from 2023.1.1f1 to 2023.1.5f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.ide.vscode": "1.2.5",
-    "com.unity.test-framework": "1.3.7",
+    "com.unity.test-framework": "1.3.8",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -57,7 +57,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.3.7",
+      "version": "1.3.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2023.1.1f1
-m_EditorVersionWithRevision: 2023.1.1f1 (46620eadcc07)
+m_EditorVersion: 2023.1.5f1
+m_EditorVersionWithRevision: 2023.1.5f1 (9dce81d9e7e0)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2023.1.5f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2023.1.5f1-webgl2
* https://deml.io/experiments/unity-webgl/2023.1.5f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)