### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.3f1 to 2022.3.7f1-urp

### DIFF
--- a/Assets/URP/UniversalRenderPipelineAsset_Renderer.asset
+++ b/Assets/URP/UniversalRenderPipelineAsset_Renderer.asset
@@ -39,6 +39,8 @@ MonoBehaviour:
       type: 3}
     objectMotionVector: {fileID: 4800000, guid: 7b3ede40266cd49a395def176e1bc486,
       type: 3}
+    dataDrivenLensFlare: {fileID: 4800000, guid: 6cda457ac28612740adb23da5d39ea92,
+      type: 3}
   m_AssetVersion: 2
   m_OpaqueLayerMask:
     serializedVersion: 2

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "2.0.5",
+    "com.unity.collab-proxy": "2.0.7",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.24",
-    "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.ide.visualstudio": "2.0.20",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "14.0.8",
     "com.unity.test-framework": "1.1.33",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.0.5",
+      "version": "2.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -50,7 +50,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.18",
+      "version": "2.0.20",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.3f1
-m_EditorVersionWithRevision: 2022.3.3f1 (7cdc2969a641)
+m_EditorVersion: 2022.3.7f1
+m_EditorVersionWithRevision: 2022.3.7f1 (b16b3b16c7a0)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.7f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.7f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.7f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)