### PR TITLE
[Automated workflow] upgrade-unity from 2022.1.24f1 to 2022.1.24f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,8 +2,8 @@
   "dependencies": {
     "com.unity.collab-proxy": "1.17.7",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.18",
-    "com.unity.ide.visualstudio": "2.0.17",
+    "com.unity.ide.rider": "3.0.27",
+    "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "13.1.9",
     "com.unity.test-framework": "1.1.33",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -43,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.18",
+      "version": "3.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -52,7 +52,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.17",
+      "version": "2.0.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.1.24f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.1.24f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.1.24f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)