### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.16f1 to 2022.3.19f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
-    "com.unity.textmeshpro": "3.0.7",
+    "com.unity.textmeshpro": "3.0.8",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -77,7 +77,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.7",
+      "version": "3.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.16f1
-m_EditorVersionWithRevision: 2022.3.16f1 (d2c21f0ef2f1)
+m_EditorVersion: 2022.3.19f1
+m_EditorVersionWithRevision: 2022.3.19f1 (244b723c30a6)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.19f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.19f1-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.19f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)