### PR TITLE
[Automated workflow] upgrade-unity from 2022.2.18f1 to 2022.2.21f1

### DIFF
--- a/Assets/Scripts/Editor/UnityPackageScripts.cs
+++ b/Assets/Scripts/Editor/UnityPackageScripts.cs
@@ -111,7 +111,7 @@ namespace UnityBuilderAction
 #if UNITY_2022_3_OR_NEWER
 					package.versions.recommended;
 #elif UNITY_2019_3_OR_NEWER
-					package.versions.verified;
+					package.versions.recommended;
 #else
 					package.versions.recommended;
 #endif

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {
-    "com.unity.ai.navigation": "1.1.3",
+    "com.unity.ai.navigation": "1.1.5",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.21",
-    "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.ide.rider": "3.0.27",
+    "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.33",
-    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.textmeshpro": "3.0.8",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.ai.navigation": {
-      "version": "1.1.3",
+      "version": "1.1.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -34,7 +34,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.21",
+      "version": "3.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -43,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.18",
+      "version": "2.0.22",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -77,7 +77,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.6",
+      "version": "3.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.18f1
-m_EditorVersionWithRevision: 2022.2.18f1 (5ebc6493a86f)
+m_EditorVersion: 2022.2.21f1
+m_EditorVersionWithRevision: 2022.2.21f1 (4907324dc95b)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.2.21f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.2.21f1-webgl2
* https://deml.io/experiments/unity-webgl/2022.2.21f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)