### PR TITLE
[Automated workflow] upgrade-unity from 2023.1.20f1 to 2023.1.20f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,12 +1,13 @@
 {
   "dependencies": {
+    "com.jd.guidresolver": "1.1.0",
     "com.unity.collab-proxy": "2.2.0",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.27",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.render-pipelines.universal": "15.0.7",
     "com.unity.test-framework": "1.3.9",
-    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.textmeshpro": "3.0.8",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",
@@ -32,8 +33,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-    "com.jd.guidresolver": "1.1.0"
+    "com.unity.modules.xr": "1.0.0"
   },
   "scopedRegistries": [
     {

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.jd.guidresolver": {
+      "version": "1.1.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "3.0.2"
+      },
+      "url": "https://package.openupm.com"
+    },
     "com.unity.burst": {
       "version": "1.8.9",
       "depth": 1,
@@ -65,6 +74,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.render-pipelines.core": {
       "version": "15.0.7",
       "depth": 1,
@@ -123,7 +139,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.6",
+      "version": "3.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2023.1.20f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2023.1.20f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2023.1.20f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)