### PR TITLE
docs: add explanation on proper web compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Version | Size | Link
 * There are some combinations for **iOS** that have **problems**: With recent versions **URP with WebGL 1** does not work at all and **builtin render pipeline with WebGL 2** has performance problems or might not load at all. I recommend to either use URP with WebGL2 or builtin with WebGL1, if you are targeting iOS. You can always test the builds on your device, to see which combination might fit your needs: https://deml.io/experiments/unity-webgl/
 * If you want to use this project as a basis for your project, be sure to select the release/branch for your unity version. Beta versions oftentimes have problems, therefore I would recommend to use the latest LTS version to run your project.
 * The server is configured to support wasm streaming and brotli compression, see [.htaccess 2020](./Configuration/2020/.htaccess)  [.htaccess 2019](./Configuration/2019/.htaccess)
-* Some servers (such as itch.io) don't support brotli compression, you should then use gzip compression instead. If brotli is misconfigured or not supported you will get an error along the lines of:
+* Due to the odd way that Unity does brotli compression, some servers (such as itch.io) don't support it, you should [learn how to manually compress your game](https://miltoncandelero.github.io/unity-webgl-compression) or use gzip compression instead. If brotli is misconfigured or not supported you will get an error along the lines of:
   ```
   Unable to parse Build/WEBGL.framework.js.br! This can happen if build compression was enabled but web server hosting the content was misconfigured to not serve the file with HTTP Response Header "Content-Encoding: br" present. Check browser Console and Devtools Network tab to debug.
   ```


### PR DESCRIPTION
Added a link to my blog post explaining how web compression works, why Unity's default brotli compression needs odd server configurations and how to properly compress a game so that it can work on most (if not all) web servers.