### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.9f1 to 6000.0.16f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.ai.navigation": "2.0.0",
+    "com.unity.ai.navigation": "2.0.3",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.31",
     "com.unity.ide.visualstudio": "2.0.22",
-    "com.unity.test-framework": "1.4.4",
+    "com.unity.test-framework": "1.4.5",
     "com.unity.ugui": "2.0.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.0",
+      "version": "2.0.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -75,7 +75,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {
-      "version": "1.4.4",
+      "version": "1.4.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.9f1
-m_EditorVersionWithRevision: 6000.0.9f1 (1490908003ac)
+m_EditorVersion: 6000.0.16f1
+m_EditorVersionWithRevision: 6000.0.16f1 (ae37dbaefed8)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.16f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.16f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.16f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)