### PR TITLE
[Automated workflow] upgrade-unity from 2021.3.38f1 to 2021.3.43f1

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -803,7 +803,7 @@ PlayerSettings:
   spritePackerPolicy: 
   webGLMemorySize: 256
   webGLExceptionSupport: 1
-  webGLNameFilesAsHashes: 1
+  webGLNameFilesAsHashes: 0
   webGLShowDiagnostics: 0
   webGLDataCaching: 1
   webGLDebugSymbols: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.43f1
-m_EditorVersionWithRevision: 2021.3.43f1 (6f9470916942)
+m_EditorVersion: 2021.3.45f1
+m_EditorVersionWithRevision: 2021.3.45f1 (0da89fac8e79)

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.38f1
-m_EditorVersionWithRevision: 2021.3.38f1 (7a2fa5d8d101)
+m_EditorVersion: 2021.3.43f1
+m_EditorVersionWithRevision: 2021.3.43f1 (6f9470916942)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2021.3.43f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2021.3.43f1-webgl2
* https://deml.io/experiments/unity-webgl/2021.3.43f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)