### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.50f1 to 2022.3.52f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.jd.guidresolver": "1.1.0",
     "com.unity.collab-proxy": "2.5.2",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.31",
+    "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.render-pipelines.universal": "14.0.11",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -51,7 +51,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.31",
+      "version": "3.0.34",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.50f1
-m_EditorVersionWithRevision: 2022.3.50f1 (c3db7f8bf9b1)
+m_EditorVersion: 2022.3.52f1
+m_EditorVersionWithRevision: 2022.3.52f1 (1120fcb54228)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.52f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.52f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.52f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)