### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.31f1 to 6000.0.32f1-urp

### DIFF
--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -179,6 +179,8 @@ MonoBehaviour:
           type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862,
           type: 2}
+        m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40,
+          type: 2}
     - rid: 774585207205396488
       type: {class: UniversalRenderPipelineDebugShaders, ns: UnityEngine.Rendering.Universal,
         asm: Unity.RenderPipelines.Universal.Runtime}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.collab-proxy": "2.5.2",
+    "com.unity.collab-proxy": "2.6.0",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.5.2",
+      "version": "2.6.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.31f1
-m_EditorVersionWithRevision: 6000.0.31f1 (a206c360e2a8)
+m_EditorVersion: 6000.0.32f1
+m_EditorVersionWithRevision: 6000.0.32f1 (b2e806cf271c)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.32f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.32f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.32f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)