### PR TITLE
[Automated workflow] upgrade-unity from 2022.3.54f1-urp to 2022.3.56f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.collab-proxy": "2.5.2",
+    "com.unity.collab-proxy": "2.6.0",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.5.2",
+      "version": "2.6.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.3.54f1
-m_EditorVersionWithRevision: 2022.3.54f1 (129125d4e700)
+m_EditorVersion: 2022.3.56f1
+m_EditorVersionWithRevision: 2022.3.56f1 (dd0c98481d00)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2022.3.56f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2022.3.56f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/2022.3.56f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)