### PR TITLE
[Automated workflow] upgrade-unity from 2023.1.20f1 to 2023.1.20f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.31",
+    "com.unity.ide.rider": "3.0.34",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.3.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -34,7 +34,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.31",
+      "version": "3.0.34",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 2023.1.20f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/2023.1.20f1-webgl2
* https://deml.io/experiments/unity-webgl/2023.1.20f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)