### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.40f1 to 6000.0.42f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,7 +3,7 @@
     "com.jd.guidresolver": "1.1.0",
     "com.unity.ai.navigation": "2.0.6",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.34",
+    "com.unity.ide.rider": "3.0.35",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.test-framework": "1.4.6",
     "com.unity.ugui": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -43,7 +43,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
-      "version": "3.0.34",
+      "version": "3.0.35",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.40f1
-m_EditorVersionWithRevision: 6000.0.40f1 (157d81624ddf)
+m_EditorVersion: 6000.0.42f1
+m_EditorVersionWithRevision: 6000.0.42f1 (feb9a7235030)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.42f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.42f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.42f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)