### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.45f1 to 6000.0.48f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.ai.navigation": "2.0.6",
+    "com.unity.ai.navigation": "2.0.7",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.35",
+    "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.5.1",
     "com.unity.ugui": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.6",
+      "version": "2.0.7",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -42,7 +42,7 @@
       "dependencies": {}
     },
     "com.unity.ide.rider": {
-      "version": "3.0.35",
+      "version": "3.0.36",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -67,7 +67,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
-      "version": "2.0.1",
+      "version": "2.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.45f1
-m_EditorVersionWithRevision: 6000.0.45f1 (d91bd3d4e081)
+m_EditorVersion: 6000.0.48f1
+m_EditorVersionWithRevision: 6000.0.48f1 (170d2541580d)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.48f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.48f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.48f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)