### PR TITLE
[Automated workflow] upgrade-unity from 6000.1.1f1 to 6000.1.7f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.ai.navigation": "2.0.7",
+    "com.unity.ai.navigation": "2.0.8",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.multiplayer.center": "1.0.0",
     "com.unity.test-framework": "1.5.1",
     "com.unity.ugui": "2.0.0",
-    "com.unity.web.stripping-tool": "1.0.0",
+    "com.unity.web.stripping-tool": "1.1.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.7",
+      "version": "2.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -101,12 +101,12 @@
       }
     },
     "com.unity.web.stripping-tool": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.settings-manager": "2.0.1",
-        "com.unity.nuget.newtonsoft-json": "3.2.1"
+        "com.unity.nuget.newtonsoft-json": "3.2.1",
+        "com.unity.settings-manager": "2.0.1"
       },
       "url": "https://packages.unity.com"
     },

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.1.1f1
-m_EditorVersionWithRevision: 6000.1.1f1 (7197418f847b)
+m_EditorVersion: 6000.1.7f1
+m_EditorVersionWithRevision: 6000.1.7f1 (13a8ffad9172)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.1.7f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.1.7f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.1.7f1-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)