### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.48f1-urp to 6000.0.51f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.collab-proxy": "2.7.1",
+    "com.unity.collab-proxy": "2.8.2",
     "com.unity.connect.share": "4.2.3",
     "com.unity.ide.rider": "3.0.36",
     "com.unity.ide.visualstudio": "2.0.23",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.7.1",
+      "version": "2.8.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.48f1
-m_EditorVersionWithRevision: 6000.0.48f1 (170d2541580d)
+m_EditorVersion: 6000.0.51f1
+m_EditorVersionWithRevision: 6000.0.51f1 (01c3ff5872c5)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.51f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.51f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.51f1-urp-webgl1

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)