### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.51f1 to 6000.0.58f2

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.1.0",
-    "com.unity.ai.navigation": "2.0.8",
+    "com.unity.ai.navigation": "2.0.9",
     "com.unity.connect.share": "4.2.3",
-    "com.unity.ide.rider": "3.0.36",
+    "com.unity.ide.rider": "3.0.38",
     "com.unity.ide.visualstudio": "2.0.23",
     "com.unity.test-framework": "1.5.1",
     "com.unity.ugui": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.8",
+      "version": "2.0.9",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -42,7 +42,7 @@
       "dependencies": {}
     },
     "com.unity.ide.rider": {
-      "version": "3.0.36",
+      "version": "3.0.38",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.51f1
-m_EditorVersionWithRevision: 6000.0.51f1 (01c3ff5872c5)
+m_EditorVersion: 6000.0.58f2
+m_EditorVersionWithRevision: 6000.0.58f2 (92dee566b325)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.58f2

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.58f2-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.58f2-webgl2-debug
* https://deml.io/experiments/unity-webgl/6000.0.58f2-minsize-webgl2

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)