### PR TITLE
[Automated workflow] upgrade-unity from 6000.0.64f1-urp to 6000.0.66f2-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.2.0",
-    "com.unity.collab-proxy": "2.10.2",
+    "com.unity.collab-proxy": "2.11.3",
     "com.unity.connect.share": "4.2.4",
-    "com.unity.ide.rider": "3.0.38",
+    "com.unity.ide.rider": "3.0.39",
     "com.unity.ide.visualstudio": "2.0.26",
     "com.unity.render-pipelines.universal": "17.0.4",
     "com.unity.test-framework": "1.6.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.burst": {
-      "version": "1.8.26",
+      "version": "1.8.27",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -20,7 +20,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collab-proxy": {
-      "version": "2.10.2",
+      "version": "2.11.3",
       "depth": 0,
       "source": "registry",
       "dependencies": {},
@@ -63,7 +63,7 @@
       "dependencies": {}
     },
     "com.unity.ide.rider": {
-      "version": "3.0.38",
+      "version": "3.0.39",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.0.64f1
-m_EditorVersionWithRevision: 6000.0.64f1 (5360b7cd7953)
+m_EditorVersion: 6000.0.66f2
+m_EditorVersionWithRevision: 6000.0.66f2 (b20bc5da3050)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.0.66f2-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.0.66f2-urp-webgl2
* https://deml.io/experiments/unity-webgl/6000.0.66f2-urp-webgl2-debug
* https://deml.io/experiments/unity-webgl/6000.0.66f2-urp-minsize-webgl2

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)