### PR TITLE
[Automated workflow] upgrade-unity from 6000.3.4f1 to 6000.3.11f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.2.0",
-    "com.unity.ai.navigation": "2.0.9",
+    "com.unity.ai.navigation": "2.0.12",
     "com.unity.connect.share": "4.2.4",
-    "com.unity.ide.rider": "3.0.38",
-    "com.unity.ide.visualstudio": "2.0.26",
+    "com.unity.ide.rider": "3.0.39",
+    "com.unity.ide.visualstudio": "2.0.27",
     "com.unity.multiplayer.center": "1.0.1",
     "com.unity.test-framework": "1.6.0",
     "com.unity.ugui": "2.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.9",
+      "version": "2.0.12",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -42,7 +42,7 @@
       "dependencies": {}
     },
     "com.unity.ide.rider": {
-      "version": "3.0.38",
+      "version": "3.0.39",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -51,7 +51,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.26",
+      "version": "2.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.3.4f1
-m_EditorVersionWithRevision: 6000.3.4f1 (fdd3b8998ec4)
+m_EditorVersion: 6000.3.11f1
+m_EditorVersionWithRevision: 6000.3.11f1 (3000ef702840)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.3.11f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.3.11f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.3.11f1-webgl2-debug
* https://deml.io/experiments/unity-webgl/6000.3.11f1-minsize-webgl2

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)