### PR TITLE
[Automated workflow] upgrade-unity from 6000.5.3f1 to 6000.5.11f1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "com.jd.guidresolver": "1.2.0",
-    "com.unity.ai.navigation": "2.0.13",
+    "com.unity.ai.navigation": "2.0.14",
     "com.unity.connect.share": "4.2.4",
     "com.unity.ide.rider": "3.0.40",
-    "com.unity.ide.visualstudio": "2.0.27",
+    "com.unity.ide.visualstudio": "2.0.28",
     "com.unity.multiplayer.center": "1.0.1",
     "com.unity.test-framework": "1.7.0",
     "com.unity.ugui": "2.5.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -10,7 +10,7 @@
       "url": "https://package.openupm.com"
     },
     "com.unity.ai.navigation": {
-      "version": "2.0.13",
+      "version": "2.0.14",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -51,7 +51,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.27",
+      "version": "2.0.28",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectAuditorSettings.asset
+++ b/ProjectSettings/ProjectAuditorSettings.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 0}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEditor.ProjectAuditorModule:Unity.ProjectAuditor.Editor:ProjectAuditorSettings
+  Rules:
+    rules: []
+  DiagnosticParams:
+    paramsStack:
+    - PlatformGroup:
+        m_String: Unknown
+      m_SerializedParams:
+      - Key: SpriteAtlasEmptySpaceLimit
+        Value: 50
+      - Key: StreamingAssetsFolderSizeLimit
+        Value: 50
+      - Key: TextureStreamingMipmapsSizeLimit
+        Value: 4000
+      - Key: StreamingClipThresholdBytes
+        Value: 218294
+      - Key: LongDecompressedClipThresholdBytes
+        Value: 204800
+      - Key: LongCompressedMobileClipThresholdBytes
+        Value: 204800
+      - Key: LoadInBackGroundClipSizeThresholdBytes
+        Value: 204800
+    CurrentParamsIndex: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.5.3f1
-m_EditorVersionWithRevision: 6000.5.3f1 (c2eb47b3a2a9)
+m_EditorVersion: 6000.5.11f1
+m_EditorVersionWithRevision: 6000.5.11f1 (5c3a1087d8e4)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.5.11f1

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.5.11f1-webgl2
* https://deml.io/experiments/unity-webgl/6000.5.11f1-webgl2-debug
* https://deml.io/experiments/unity-webgl/6000.5.11f1-minsize-webgl2

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)