### PR TITLE
[Automated workflow] upgrade-unity from 6000.5.8f1-urp to 6000.5.11f1-urp

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.unity.collab-proxy": "2.13.6",
     "com.unity.connect.share": "4.2.4",
     "com.unity.ide.rider": "3.0.40",
-    "com.unity.ide.visualstudio": "2.0.27",
+    "com.unity.ide.visualstudio": "2.0.28",
     "com.unity.render-pipelines.universal": "17.5.0",
     "com.unity.test-framework": "1.7.0",
     "com.unity.ugui": "2.5.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -70,7 +70,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.27",
+      "version": "2.0.28",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectAuditorSettings.asset
+++ b/ProjectSettings/ProjectAuditorSettings.asset
@@ -19,6 +19,12 @@ MonoBehaviour:
     - PlatformGroup:
         m_String: Unknown
       m_SerializedParams:
+      - Key: SpriteAtlasEmptySpaceLimit
+        Value: 50
+      - Key: StreamingAssetsFolderSizeLimit
+        Value: 50
+      - Key: TextureStreamingMipmapsSizeLimit
+        Value: 4000
       - Key: StreamingClipThresholdBytes
         Value: 218294
       - Key: LongDecompressedClipThresholdBytes
@@ -27,10 +33,4 @@ MonoBehaviour:
         Value: 204800
       - Key: LoadInBackGroundClipSizeThresholdBytes
         Value: 204800
-      - Key: StreamingAssetsFolderSizeLimit
-        Value: 50
-      - Key: TextureStreamingMipmapsSizeLimit
-        Value: 4000
-      - Key: SpriteAtlasEmptySpaceLimit
-        Value: 50
     CurrentParamsIndex: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.5.8f1
-m_EditorVersionWithRevision: 6000.5.8f1 (5cb7df797b7d)
+m_EditorVersion: 6000.5.11f1
+m_EditorVersionWithRevision: 6000.5.11f1 (5c3a1087d8e4)


### PR DESCRIPTION
## [Automated Workflow] Upgrade unity to 6000.5.11f1-urp

>  [workflow file](https://github.com/JohannesDeml/UnityWebGL-LoadingTest/blob/master/.github/workflows/upgrade-unity.yml) using [create-pull-request](https://github.com/peter-evans/create-pull-request) & [render-template](https://github.com/chuhlomin/render-template)

### Built version demos

* https://deml.io/experiments/unity-webgl/6000.5.11f1-urp-webgl2
* https://deml.io/experiments/unity-webgl/6000.5.11f1-urp-webgl2-debug
* https://deml.io/experiments/unity-webgl/6000.5.11f1-urp-minsize-webgl2

### Other links

* [All builds](https://deml.io/experiments/unity-webgl)
* [Game CI docker images](https://game.ci/docs/docker/versions)
* [Unity Download Archive](https://unity.com/releases/editor/archive)